### PR TITLE
Fix #22 : JsonSettingsFile should throw an exception

### DIFF
--- a/src/test/java/tests/utilities/SettingsFileTests.java
+++ b/src/test/java/tests/utilities/SettingsFileTests.java
@@ -2,22 +2,23 @@ package tests.utilities;
 
 import aquality.selenium.core.applications.AqualityModule;
 import aquality.selenium.core.utilities.ISettingsFile;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import tests.application.CustomAqualityServices;
 import tests.application.TestModule;
 import tests.configurations.BaseProfileTest;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Consumer;
 
 import static org.testng.Assert.*;
 
 public class SettingsFileTests extends BaseProfileTest {
     private static final String TIMEOUT_POLLING_INTERVAL_PATH = "/timeouts/timeoutPollingInterval";
+    private static final String NULLVALUE_PATH = "/nullValue";
     private static final String TIMEOUT_POLLING_INTERVAL_KEY = "timeouts.timeoutPollingInterval";
     private static final String LANGUAGE_ENV_KEY = "logger.language";
     private static final String ARGUMENTS_ENV_KEY = "arguments.start";
@@ -101,6 +102,28 @@ public class SettingsFileTests extends BaseProfileTest {
         String wrongPath = "/blabla";
         boolean isWrongPathPresent = jsonSettingsFile.isValuePresent(wrongPath);
         assertFalse(isWrongPathPresent, String.format("%s value should not be present in settings file '%s'", wrongPath, FILE_NAME));
+    }
+
+    @Test
+    public void testShouldBePossibleToCheckThatNullValueIsPresent() {
+        boolean isNullValuePresent = jsonSettingsFile.isValuePresent(NULLVALUE_PATH);
+        assertTrue(isNullValuePresent, String.format("%s value should be present in settings file '%s'", NULLVALUE_PATH, FILE_NAME));
+    }
+
+    @DataProvider
+    public Object[] actionsToGetValue() {
+        List<Consumer<String>> actionsList = new ArrayList<>();
+        actionsList.add(path -> jsonSettingsFile.getValue(path));
+        actionsList.add(path -> jsonSettingsFile.getMap(path));
+        actionsList.add(path -> jsonSettingsFile.getList(path));
+        return actionsList.toArray();
+    }
+
+    @Test(dataProvider = "actionsToGetValue")
+    public void testShouldThrowExceptionWhenValueNotFound(Consumer<String> action) {
+        String wrongPath = "/blabla";
+        Assert.assertFalse(jsonSettingsFile.isValuePresent(wrongPath), String.format("%s value should not be present in settings file '%s'", wrongPath, FILE_NAME));
+        Assert.assertThrows(IllegalArgumentException.class, () -> action.accept(wrongPath));
     }
 
     @AfterMethod

--- a/src/test/resources/settings.jsontest.json
+++ b/src/test/resources/settings.jsontest.json
@@ -14,5 +14,6 @@
   },
   "arguments": {
     "start": ["first","second"]
-  }
+  },
+  "nullValue": null
 }


### PR DESCRIPTION
Fix #22 : JsonSettingsFile should throw an exception when there are no values found by jsonPath

### PR Details

<!--- Provide a general summary of your changes in the Title above -->

##### Related Issue Link: 
fixes #22 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

##### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

##### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
