### PR TITLE
Feature/45 add find child elements to element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.aquality-automation</groupId>
     <artifactId>aquality-selenium-core</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <packaging>jar</packaging>
     <name>Aquality Selenium Core</name>

--- a/src/main/java/aquality/selenium/core/elements/Element.java
+++ b/src/main/java/aquality/selenium/core/elements/Element.java
@@ -130,12 +130,12 @@ public abstract class Element implements IElement {
     }
 
     @Override
-    public <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementsCount count, ElementState state) {
+    public <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementState state, ElementsCount count) {
         return getElementFactory().findChildElements(this, childLoc, name, clazz, count, state);
     }
 
     @Override
-    public <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+    public <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier, ElementState state, ElementsCount count) {
         return getElementFactory().findChildElements(this, childLoc, name, supplier, count, state);
     }
 

--- a/src/main/java/aquality/selenium/core/elements/Element.java
+++ b/src/main/java/aquality/selenium/core/elements/Element.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Supplier;
 
 public abstract class Element implements IElement {
@@ -126,6 +127,16 @@ public abstract class Element implements IElement {
     @Override
     public <T extends IElement> T findChildElement(By childLoc, String name, IElementSupplier<T> supplier, ElementState state) {
         return getElementFactory().findChildElement(this, childLoc, name, supplier, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementsCount count, ElementState state) {
+        return getElementFactory().findChildElements(this, childLoc, name, clazz, count, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        return getElementFactory().findChildElements(this, childLoc, name, supplier, count, state);
     }
 
     protected <T> T doWithRetry(Supplier<T> action) {

--- a/src/main/java/aquality/selenium/core/elements/ElementFactory.java
+++ b/src/main/java/aquality/selenium/core/elements/ElementFactory.java
@@ -135,7 +135,7 @@ public class ElementFactory implements IElementFactory {
      * @return target element's locator
      */
     protected By generateXpathLocator(By multipleElementsLocator, WebElement webElement, int elementIndex) {
-        if (isLocatorSupportedForXPathGeneration(multipleElementsLocator)) {
+        if (isLocatorSupportedForXPathExtraction(multipleElementsLocator)) {
             return By.xpath(
                     String.format("(%1$s)[%2$s]", extractXPathFromLocator(multipleElementsLocator), elementIndex));
         }
@@ -173,8 +173,8 @@ public class ElementFactory implements IElementFactory {
      * @return absolute locator of the child
      */
     protected By generateAbsoluteChildLocator(By parentLoc, By childLoc) {
-        return isLocatorSupportedForXPathGeneration(parentLoc)
-                && isLocatorSupportedForXPathGeneration(childLoc)
+        return isLocatorSupportedForXPathExtraction(parentLoc)
+                && isLocatorSupportedForXPathExtraction(childLoc)
                 && !extractXPathFromLocator(childLoc).startsWith(".")
                 ? By.xpath(extractXPathFromLocator(parentLoc).concat(extractXPathFromLocator(childLoc)))
                 : new ByChained(parentLoc, childLoc);
@@ -188,7 +188,7 @@ public class ElementFactory implements IElementFactory {
      * @param locator locator to transform
      * @return true if the locator can be transformed to xpath, false otherwise.
      */
-    protected boolean isLocatorSupportedForXPathGeneration(By locator) {
+    protected boolean isLocatorSupportedForXPathExtraction(By locator) {
         return locator.getClass().equals(ByXPath.class) || locator.getClass().equals(ByTagName.class);
     }
 

--- a/src/main/java/aquality/selenium/core/elements/ElementFactory.java
+++ b/src/main/java/aquality/selenium/core/elements/ElementFactory.java
@@ -64,6 +64,19 @@ public class ElementFactory implements IElementFactory {
     }
 
     @Override
+    public <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name, Class<T> clazz, ElementsCount count, ElementState state) {
+        IElementSupplier<T> elementSupplier = getDefaultElementSupplier(clazz);
+        return findChildElements(parentElement, childLoc, name, elementSupplier, count, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        String childName = name == null ? "Child element of ".concat(parentElement.getName()) : name;
+        By fullLocator = new ByChained(parentElement.getLocator(), childLoc);
+        return findElements(fullLocator, childName, supplier, count, state);
+    }
+
+    @Override
     public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier,
                                                      ElementsCount count, ElementState state) {
         try {

--- a/src/main/java/aquality/selenium/core/elements/ElementFactory.java
+++ b/src/main/java/aquality/selenium/core/elements/ElementFactory.java
@@ -173,11 +173,13 @@ public class ElementFactory implements IElementFactory {
      * @return absolute locator of the child
      */
     protected By generateAbsoluteChildLocator(By parentLoc, By childLoc) {
-        return isLocatorSupportedForXPathExtraction(parentLoc)
-                && isLocatorSupportedForXPathExtraction(childLoc)
-                && !extractXPathFromLocator(childLoc).startsWith(".")
-                ? By.xpath(extractXPathFromLocator(parentLoc).concat(extractXPathFromLocator(childLoc)))
-                : new ByChained(parentLoc, childLoc);
+        if (isLocatorSupportedForXPathExtraction(parentLoc) && isLocatorSupportedForXPathExtraction(childLoc)) {
+            String childLocString = extractXPathFromLocator(childLoc);
+            String parentLocString = extractXPathFromLocator(parentLoc);
+            return By.xpath(parentLocString.concat(
+                    childLocString.startsWith(".") ? childLocString.substring(1) : childLocString));
+        }
+        return new ByChained(parentLoc, childLoc);
     }
 
     /**

--- a/src/main/java/aquality/selenium/core/elements/interfaces/IElementFactory.java
+++ b/src/main/java/aquality/selenium/core/elements/interfaces/IElementFactory.java
@@ -76,7 +76,7 @@ public interface IElementFactory {
                                             Class<T> clazz, ElementState state);
 
     /**
-     * Finds child element in any state by its locator relative to parent element.
+     * Finds displayed child element by its locator relative to parent element.
      *
      * @param childLoc      Locator of child element relative to its parent.
      * @param clazz         Class or interface of the element to be obtained.
@@ -87,7 +87,7 @@ public interface IElementFactory {
      */
     default <T extends IElement> T findChildElement(IElement parentElement, By childLoc, String name,
                                                     Class<T> clazz) {
-        return findChildElement(parentElement, childLoc, name, clazz, ElementState.EXISTS_IN_ANY_STATE);
+        return findChildElement(parentElement, childLoc, name, clazz, ElementState.DISPLAYED);
     }
 
     /**
@@ -178,6 +178,239 @@ public interface IElementFactory {
     }
 
     /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           Class<T> clazz) {
+        return findChildElements(parentElement, childLoc, clazz, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           Class<T> clazz, ElementsCount count) {
+        return findChildElements(parentElement, childLoc, clazz, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           Class<T> clazz,
+                                                           ElementState state) {
+        return findChildElements(parentElement, childLoc, clazz, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           Class<T> clazz, ElementsCount count,
+                                                           ElementState state) {
+        return findChildElements(parentElement, childLoc, null, clazz, count, state);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           Class<T> clazz) {
+        return findChildElements(parentElement, childLoc, name, clazz, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           Class<T> clazz, ElementsCount count) {
+        return findChildElements(parentElement, childLoc, name, clazz, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           Class<T> clazz, ElementState state) {
+        return findChildElements(parentElement, childLoc, name, clazz, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param name          Child elements name.
+     * @param parentElement Parent element for relative search of child elements.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of target elements.
+     * @param <T>           Type of the target elements.
+     * @return List of child elements.
+     */
+    <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name, Class<T> clazz,
+                                                   ElementsCount count, ElementState state);
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           IElementSupplier<T> supplier) {
+        return findChildElements(parentElement, childLoc, supplier, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           IElementSupplier<T> supplier, ElementsCount count) {
+        return findChildElements(parentElement, childLoc, supplier, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           IElementSupplier<T> supplier,
+                                                           ElementState state) {
+        return findChildElements(parentElement, childLoc, supplier, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc,
+                                                           IElementSupplier<T> supplier, ElementsCount count,
+                                                           ElementState state) {
+        return findChildElements(parentElement, childLoc, null, supplier, count, state);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           IElementSupplier<T> supplier) {
+        return findChildElements(parentElement, childLoc, name, supplier, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           IElementSupplier<T> supplier, ElementsCount count) {
+        return findChildElements(parentElement, childLoc, name, supplier, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param parentElement Parent element for relative search of child elements.
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                           IElementSupplier<T> supplier, ElementState state) {
+        return findChildElements(parentElement, childLoc, name, supplier, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param name          Child elements name.
+     * @param parentElement Parent element for relative search of child elements.
+     * @param state         Visibility state of child elements.
+     * @param <T>           Type of the target elements.
+     * @return List of child elements.
+     */
+    <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                   IElementSupplier<T> supplier, ElementsCount count, ElementState state);
+
+    /**
      * Find list of elements.
      *
      * @param locator  Elements selector.
@@ -213,7 +446,7 @@ public interface IElementFactory {
      * @param name    Child element name.
      * @param clazz   Class or interface of the element to be obtained.
      * @param count   Expected number of elements that have to be found (zero, more then zero, any).
-     * @param state    Visibility state of target elements.
+     * @param state   Visibility state of target elements.
      * @param <T>     Type of the target element.
      * @return List of elements.
      */
@@ -225,7 +458,7 @@ public interface IElementFactory {
      * @param locator Elements selector.
      * @param clazz   Class or interface of the element to be obtained.
      * @param count   Expected number of elements that have to be found (zero, more then zero, any).
-     * @param state    Visibility state of target elements.
+     * @param state   Visibility state of target elements.
      * @param <T>     Type of the target element.
      * @return List of elements.
      */

--- a/src/main/java/aquality/selenium/core/elements/interfaces/IElementFactory.java
+++ b/src/main/java/aquality/selenium/core/elements/interfaces/IElementFactory.java
@@ -428,6 +428,62 @@ public interface IElementFactory {
      * Find list of elements.
      *
      * @param locator  Elements selector.
+     * @param name     Child element name.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of target elements.
+     * @param <T>      Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier,
+                                                      ElementState state) {
+        return findElements(locator, name, supplier, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Find list of elements.
+     *
+     * @param locator  Elements selector.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of target elements.
+     * @param <T>      Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier,
+                                                      ElementState state) {
+        return findElements(locator, null, supplier, state);
+    }
+
+    /**
+     * Find list of displayed elements.
+     *
+     * @param locator  Elements selector.
+     * @param name     Child element name.
+     * @param supplier Required elements' supplier.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
+     * @param <T>      Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementsCount count) {
+        return findElements(locator, name, supplier, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Find list of displayed elements.
+     *
+     * @param locator  Elements selector.
+     * @param name     Child element name.
+     * @param supplier Required elements' supplier.
+     * @param <T>      Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier) {
+        return findElements(locator, name, supplier, ElementsCount.ANY);
+    }
+
+    /**
+     * Find list of elements.
+     *
+     * @param locator  Elements selector.
      * @param supplier Required elements' supplier.
      * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @param state    Visibility state of target elements.
@@ -456,6 +512,20 @@ public interface IElementFactory {
      * Find list of elements.
      *
      * @param locator Elements selector.
+     * @param name    Child element name.
+     * @param clazz   Class or interface of the element to be obtained.
+     * @param state   Visibility state of target elements.
+     * @param <T>     Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz, ElementState state) {
+        return findElements(locator, name, clazz, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Find list of elements.
+     *
+     * @param locator Elements selector.
      * @param clazz   Class or interface of the element to be obtained.
      * @param count   Expected number of elements that have to be found (zero, more then zero, any).
      * @param state   Visibility state of target elements.
@@ -464,6 +534,19 @@ public interface IElementFactory {
      */
     default <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementsCount count, ElementState state) {
         return findElements(locator, null, clazz, count, state);
+    }
+
+    /**
+     * Find list of elements.
+     *
+     * @param locator Elements selector.
+     * @param clazz   Class or interface of the element to be obtained.
+     * @param state   Visibility state of target elements.
+     * @param <T>     Type of the target element.
+     * @return List of elements.
+     */
+    default <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementState state) {
+        return findElements(locator, null, clazz, ElementsCount.ANY, state);
     }
 
     /**

--- a/src/main/java/aquality/selenium/core/elements/interfaces/IParent.java
+++ b/src/main/java/aquality/selenium/core/elements/interfaces/IParent.java
@@ -1,7 +1,10 @@
 package aquality.selenium.core.elements.interfaces;
 
 import aquality.selenium.core.elements.ElementState;
+import aquality.selenium.core.elements.ElementsCount;
 import org.openqa.selenium.By;
+
+import java.util.List;
 
 public interface IParent {
 
@@ -104,4 +107,221 @@ public interface IParent {
     default <T extends IElement> T findChildElement(By childLoc, IElementSupplier<T> supplier) {
         return findChildElement(childLoc, null, supplier, ElementState.DISPLAYED);
     }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           Class<T> clazz) {
+        return findChildElements(childLoc, clazz, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           Class<T> clazz, ElementsCount count) {
+        return findChildElements(childLoc, clazz, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           Class<T> clazz,
+                                                           ElementState state) {
+        return findChildElements(childLoc, clazz, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           Class<T> clazz, ElementsCount count,
+                                                           ElementState state) {
+        return findChildElements(childLoc, null, clazz, count, state);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           Class<T> clazz) {
+        return findChildElements(childLoc, name, clazz, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           Class<T> clazz, ElementsCount count) {
+        return findChildElements(childLoc, name, clazz, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           Class<T> clazz, ElementState state) {
+        return findChildElements(childLoc, name, clazz, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param clazz         Class or interface of the elements to be obtained.
+     * @param name          Child elements name.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of target elements.
+     * @param <T>           Type of the target elements.
+     * @return List of child elements.
+     */
+    <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz,
+                                                   ElementsCount count, ElementState state);
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           IElementSupplier<T> supplier) {
+        return findChildElements(childLoc, supplier, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           IElementSupplier<T> supplier, ElementsCount count) {
+        return findChildElements(childLoc, supplier, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           IElementSupplier<T> supplier,
+                                                           ElementState state) {
+        return findChildElements(childLoc, supplier, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc,
+                                                           IElementSupplier<T> supplier, ElementsCount count,
+                                                           ElementState state) {
+        return findChildElements(childLoc, null, supplier, count, state);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           IElementSupplier<T> supplier) {
+        return findChildElements(childLoc, name, supplier, ElementsCount.ANY);
+    }
+
+    /**
+     * Finds displayed child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           IElementSupplier<T> supplier, ElementsCount count) {
+        return findChildElements(childLoc, name, supplier, count, ElementState.DISPLAYED);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param name          Child elements name.
+     * @param supplier      Required elements' supplier.
+     * @param state         Visibility state of child elements.
+     * @return List of child elements.
+     */
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                           IElementSupplier<T> supplier, ElementState state) {
+        return findChildElements(childLoc, name, supplier, ElementsCount.ANY, state);
+    }
+
+    /**
+     * Finds child elements by their locator relative to parent element.
+     *
+     * @param childLoc      Locator of child elements relative to its parent.
+     * @param supplier      Required elements' supplier.
+     * @param name          Child elements name.
+     * @param state         Visibility state of child elements.
+     * @param <T>           Type of the target elements.
+     * @return List of child elements.
+     */
+    <T extends IElement> List<T> findChildElements(By childLoc, String name,
+                                                   IElementSupplier<T> supplier, ElementsCount count, ElementState state);
 }

--- a/src/main/java/aquality/selenium/core/elements/interfaces/IParent.java
+++ b/src/main/java/aquality/selenium/core/elements/interfaces/IParent.java
@@ -111,217 +111,205 @@ public interface IParent {
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param clazz         Class or interface of the elements to be obtained.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param clazz    Class or interface of the elements to be obtained.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           Class<T> clazz) {
+    default <T extends IElement> List<T> findChildElements(By childLoc, Class<T> clazz) {
         return findChildElements(childLoc, clazz, ElementsCount.ANY);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           Class<T> clazz, ElementsCount count) {
-        return findChildElements(childLoc, clazz, count, ElementState.DISPLAYED);
+    default <T extends IElement> List<T> findChildElements(By childLoc, Class<T> clazz, ElementsCount count) {
+        return findChildElements(childLoc, clazz, ElementState.DISPLAYED, count);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param state    Visibility state of child elements.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           Class<T> clazz,
-                                                           ElementState state) {
-        return findChildElements(childLoc, clazz, ElementsCount.ANY, state);
+    default <T extends IElement> List<T> findChildElements(By childLoc, Class<T> clazz, ElementState state) {
+        return findChildElements(childLoc, clazz, state, ElementsCount.ANY);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param state    Visibility state of child elements.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           Class<T> clazz, ElementsCount count,
-                                                           ElementState state) {
-        return findChildElements(childLoc, null, clazz, count, state);
+    default <T extends IElement> List<T> findChildElements(By childLoc, Class<T> clazz, ElementState state,
+                                                           ElementsCount count) {
+        return findChildElements(childLoc, null, clazz, state, count);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param clazz         Class or interface of the elements to be obtained.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param clazz    Class or interface of the elements to be obtained.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           Class<T> clazz) {
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz) {
         return findChildElements(childLoc, name, clazz, ElementsCount.ANY);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           Class<T> clazz, ElementsCount count) {
-        return findChildElements(childLoc, name, clazz, count, ElementState.DISPLAYED);
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementsCount count) {
+        return findChildElements(childLoc, name, clazz, ElementState.DISPLAYED, count);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param state    Visibility state of child elements.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           Class<T> clazz, ElementState state) {
-        return findChildElements(childLoc, name, clazz, ElementsCount.ANY, state);
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementState state) {
+        return findChildElements(childLoc, name, clazz, state, ElementsCount.ANY);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param clazz         Class or interface of the elements to be obtained.
-     * @param name          Child elements name.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
-     * @param state         Visibility state of target elements.
-     * @param <T>           Type of the target elements.
+     * @param <T>      Type of the target elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param clazz    Class or interface of the elements to be obtained.
+     * @param state    Visibility state of target elements.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz,
-                                                   ElementsCount count, ElementState state);
+    <T extends IElement> List<T> findChildElements(By childLoc, String name, Class<T> clazz, ElementState state,
+                                                   ElementsCount count);
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param supplier      Required elements' supplier.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param supplier Required elements' supplier.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           IElementSupplier<T> supplier) {
+    default <T extends IElement> List<T> findChildElements(By childLoc, IElementSupplier<T> supplier) {
         return findChildElements(childLoc, supplier, ElementsCount.ANY);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param supplier      Required elements' supplier.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param supplier Required elements' supplier.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           IElementSupplier<T> supplier, ElementsCount count) {
-        return findChildElements(childLoc, supplier, count, ElementState.DISPLAYED);
+    default <T extends IElement> List<T> findChildElements(By childLoc, IElementSupplier<T> supplier,
+                                                           ElementsCount count) {
+        return findChildElements(childLoc, supplier, ElementState.DISPLAYED, count);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param supplier      Required elements' supplier.
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of child elements.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           IElementSupplier<T> supplier,
+    default <T extends IElement> List<T> findChildElements(By childLoc, IElementSupplier<T> supplier,
                                                            ElementState state) {
-        return findChildElements(childLoc, supplier, ElementsCount.ANY, state);
+        return findChildElements(childLoc, supplier, state, ElementsCount.ANY);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param supplier      Required elements' supplier.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of child elements.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc,
-                                                           IElementSupplier<T> supplier, ElementsCount count,
-                                                           ElementState state) {
-        return findChildElements(childLoc, null, supplier, count, state);
+    default <T extends IElement> List<T> findChildElements(By childLoc, IElementSupplier<T> supplier, ElementState state,
+                                                           ElementsCount count) {
+        return findChildElements(childLoc, null, supplier, state, count);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param supplier      Required elements' supplier.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param supplier Required elements' supplier.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           IElementSupplier<T> supplier) {
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier) {
         return findChildElements(childLoc, name, supplier, ElementsCount.ANY);
     }
 
     /**
      * Finds displayed child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param supplier      Required elements' supplier.
-     * @param count         Expected number of elements that have to be found (zero, more then zero, any).
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param supplier Required elements' supplier.
+     * @param count    Expected number of elements that have to be found (zero, more then zero, any).
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           IElementSupplier<T> supplier, ElementsCount count) {
-        return findChildElements(childLoc, name, supplier, count, ElementState.DISPLAYED);
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier,
+                                                           ElementsCount count) {
+        return findChildElements(childLoc, name, supplier, ElementState.DISPLAYED, count);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param name          Child elements name.
-     * @param supplier      Required elements' supplier.
-     * @param state         Visibility state of child elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of child elements.
      * @return List of child elements.
      */
-    default <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                           IElementSupplier<T> supplier, ElementState state) {
-        return findChildElements(childLoc, name, supplier, ElementsCount.ANY, state);
+    default <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier,
+                                                           ElementState state) {
+        return findChildElements(childLoc, name, supplier, state, ElementsCount.ANY);
     }
 
     /**
      * Finds child elements by their locator relative to parent element.
      *
-     * @param childLoc      Locator of child elements relative to its parent.
-     * @param supplier      Required elements' supplier.
-     * @param name          Child elements name.
-     * @param state         Visibility state of child elements.
-     * @param <T>           Type of the target elements.
+     * @param <T>      Type of the target elements.
+     * @param childLoc Locator of child elements relative to its parent.
+     * @param name     Child elements name.
+     * @param supplier Required elements' supplier.
+     * @param state    Visibility state of child elements.
      * @return List of child elements.
      */
-    <T extends IElement> List<T> findChildElements(By childLoc, String name,
-                                                   IElementSupplier<T> supplier, ElementsCount count, ElementState state);
+    <T extends IElement> List<T> findChildElements(By childLoc, String name, IElementSupplier<T> supplier,
+                                                   ElementState state, ElementsCount count);
 }

--- a/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
+++ b/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
@@ -49,6 +49,10 @@ public class CalculatorWindow {
         return By.xpath("//*[@Name='=']/parent::Window");
     }
 
+    public static By getTagNameLocator() {
+        return By.tagName("Button");
+    }
+
     public static By getResultsLabelLoc() {
         return MobileBy.AccessibilityId("48");
     }

--- a/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
+++ b/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
@@ -45,6 +45,10 @@ public class CalculatorWindow {
         return By.xpath("//*[@Name='=']");
     }
 
+    public static By getRelativeXPathLocator() {
+        return By.xpath("//*[@Name='=']");
+    }
+
     public static By getDottedXPathLocator() {
         return By.xpath("//*[@Name='=']/parent::Window");
     }

--- a/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
+++ b/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
@@ -17,6 +17,10 @@ public class CalculatorWindow {
         return new CustomElement(getWindowLocator(), "Window", ElementState.DISPLAYED);
     }
 
+    public static CustomElement getWindowByXPathLabel() {
+        return new CustomElement(By.xpath("//Window"), "Window", ElementState.DISPLAYED);
+    }
+
     public static By getOneButtonLoc() {
         return By.name("1");
     }

--- a/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
+++ b/src/test/java/tests/applications/windowsApp/CalculatorWindow.java
@@ -45,6 +45,10 @@ public class CalculatorWindow {
         return By.xpath("//*[@Name='=']");
     }
 
+    public static By getDottedXPathLocator() {
+        return By.xpath("//*[@Name='=']/parent::Window");
+    }
+
     public static By getResultsLabelLoc() {
         return MobileBy.AccessibilityId("48");
     }

--- a/src/test/java/tests/elements/factory/CustomElementFactory.java
+++ b/src/test/java/tests/elements/factory/CustomElementFactory.java
@@ -1,15 +1,23 @@
 package tests.elements.factory;
 
 import aquality.selenium.core.elements.ElementFactory;
+import aquality.selenium.core.elements.ElementState;
+import aquality.selenium.core.elements.ElementsCount;
 import aquality.selenium.core.elements.interfaces.IElement;
 import aquality.selenium.core.elements.interfaces.IElementFinder;
+import aquality.selenium.core.elements.interfaces.IElementSupplier;
 import aquality.selenium.core.localization.ILocalizationManager;
 import aquality.selenium.core.waitings.IConditionalWait;
+import org.openqa.selenium.By;
+import org.openqa.selenium.By.ByXPath;
+import org.openqa.selenium.InvalidArgumentException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CustomElementFactory extends ElementFactory {
+    private static final int XPATH_SUBSTRING_BEGIN_INDEX = 10;
     CustomElementFactory(IConditionalWait conditionalWait, IElementFinder elementFinder, ILocalizationManager localizationManager) {
         super(conditionalWait, elementFinder, localizationManager);
     }
@@ -19,6 +27,25 @@ public class CustomElementFactory extends ElementFactory {
         Map<Class<? extends IElement>, Class<? extends IElement>> typesMap = new HashMap<>();
         typesMap.put(ICustomElement.class, CustomElement.class);
         return typesMap;
+    }
+
+    @Override
+    public <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
+                                                          IElementSupplier<T> supplier, ElementsCount count,
+                                                          ElementState state) {
+        By fullLocator = By.xpath(
+                extractXPathFromLocator(parentElement.getLocator()).concat(extractXPathFromLocator(childLoc)));
+        return findElements(fullLocator, name, supplier, count, state);
+    }
+
+    private String extractXPathFromLocator(By locator) {
+        Class supportedLocatorType = ByXPath.class;
+        if (locator.getClass().equals(supportedLocatorType)) {
+            return locator.toString().substring(XPATH_SUBSTRING_BEGIN_INDEX);
+        }
+        throw new InvalidArgumentException(String.format(
+                "Cannot define xpath from locator %1$s. Locator type %2$s is not %3$s, and is not supported yet",
+                locator.toString(), locator.getClass(), supportedLocatorType));
     }
 }
 

--- a/src/test/java/tests/elements/factory/CustomElementFactory.java
+++ b/src/test/java/tests/elements/factory/CustomElementFactory.java
@@ -1,23 +1,15 @@
 package tests.elements.factory;
 
 import aquality.selenium.core.elements.ElementFactory;
-import aquality.selenium.core.elements.ElementState;
-import aquality.selenium.core.elements.ElementsCount;
 import aquality.selenium.core.elements.interfaces.IElement;
 import aquality.selenium.core.elements.interfaces.IElementFinder;
-import aquality.selenium.core.elements.interfaces.IElementSupplier;
 import aquality.selenium.core.localization.ILocalizationManager;
 import aquality.selenium.core.waitings.IConditionalWait;
-import org.openqa.selenium.By;
-import org.openqa.selenium.By.ByXPath;
-import org.openqa.selenium.InvalidArgumentException;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class CustomElementFactory extends ElementFactory {
-    private static final int XPATH_SUBSTRING_BEGIN_INDEX = 10;
     CustomElementFactory(IConditionalWait conditionalWait, IElementFinder elementFinder, ILocalizationManager localizationManager) {
         super(conditionalWait, elementFinder, localizationManager);
     }
@@ -27,25 +19,6 @@ public class CustomElementFactory extends ElementFactory {
         Map<Class<? extends IElement>, Class<? extends IElement>> typesMap = new HashMap<>();
         typesMap.put(ICustomElement.class, CustomElement.class);
         return typesMap;
-    }
-
-    @Override
-    public <T extends IElement> List<T> findChildElements(IElement parentElement, By childLoc, String name,
-                                                          IElementSupplier<T> supplier, ElementsCount count,
-                                                          ElementState state) {
-        By fullLocator = By.xpath(
-                extractXPathFromLocator(parentElement.getLocator()).concat(extractXPathFromLocator(childLoc)));
-        return findElements(fullLocator, name, supplier, count, state);
-    }
-
-    private String extractXPathFromLocator(By locator) {
-        Class supportedLocatorType = ByXPath.class;
-        if (locator.getClass().equals(supportedLocatorType)) {
-            return locator.toString().substring(XPATH_SUBSTRING_BEGIN_INDEX);
-        }
-        throw new InvalidArgumentException(String.format(
-                "Cannot define xpath from locator %1$s. Locator type %2$s is not %3$s, and is not supported yet",
-                locator.toString(), locator.getClass(), supportedLocatorType));
     }
 }
 

--- a/src/test/java/tests/elements/factory/ElementFactoryTests.java
+++ b/src/test/java/tests/elements/factory/ElementFactoryTests.java
@@ -5,10 +5,7 @@ import aquality.selenium.core.elements.ElementState;
 import aquality.selenium.core.elements.ElementsCount;
 import aquality.selenium.core.elements.interfaces.IElement;
 import aquality.selenium.core.elements.interfaces.IElementFactory;
-import aquality.selenium.core.elements.interfaces.IElementFinder;
 import aquality.selenium.core.elements.interfaces.IElementSupplier;
-import aquality.selenium.core.localization.ILocalizationManager;
-import aquality.selenium.core.waitings.IConditionalWait;
 import org.openqa.selenium.By;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -129,6 +126,16 @@ public class ElementFactoryTests implements ITestWithApplication, IFindElementsT
     }
 
     @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz, ElementState state) {
+        return customFactory().findElements(locator, name, clazz, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementState state) {
+        return customFactory().findElements(locator, clazz, state);
+    }
+
+    @Override
     public <T extends IElement> List<T> findElements(By locator, Class<T> clazz) {
         return customFactory().findElements(locator, clazz);
     }
@@ -141,6 +148,21 @@ public class ElementFactoryTests implements ITestWithApplication, IFindElementsT
     @Override
     public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
         return customFactory().findElements(locator, name, supplier, count, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementState state) {
+        return customFactory().findElements(locator, name, supplier, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementState state) {
+        return customFactory().findElements(locator, supplier, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier) {
+        return customFactory().findElements(locator, name, supplier);
     }
 
     @Override

--- a/src/test/java/tests/elements/factory/ElementFactoryTests.java
+++ b/src/test/java/tests/elements/factory/ElementFactoryTests.java
@@ -6,43 +6,22 @@ import aquality.selenium.core.elements.ElementsCount;
 import aquality.selenium.core.elements.interfaces.IElement;
 import aquality.selenium.core.elements.interfaces.IElementFactory;
 import aquality.selenium.core.elements.interfaces.IElementFinder;
+import aquality.selenium.core.elements.interfaces.IElementSupplier;
 import aquality.selenium.core.localization.ILocalizationManager;
 import aquality.selenium.core.waitings.IConditionalWait;
 import org.openqa.selenium.By;
-import org.openqa.selenium.InvalidArgumentException;
-import org.openqa.selenium.TimeoutException;
 import org.testng.Assert;
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 import tests.ITestWithApplication;
 import tests.applications.windowsApp.AqualityServices;
 import tests.applications.windowsApp.CalculatorWindow;
 
-public class ElementFactoryTests implements ITestWithApplication {
-    private static final String CONDITION_TIMEOUT_KEY = "timeouts.timeoutCondition";
-    private static final String NEW_TIMEOUT_VALUE = "5";
-    private static final int XPATH_SUBSTRING_BEGIN_INDEX = 10;
+import java.util.List;
 
-    private CustomElementFactory customFactory() {
-        return new CustomElementFactory(AqualityServices.get(IConditionalWait.class),
-                AqualityServices.get(IElementFinder.class), AqualityServices.get(ILocalizationManager.class));
-    }
+public class ElementFactoryTests implements ITestWithApplication, IFindElementsTests {
 
     private IElementFactory defaultFactory() {
         return AqualityServices.get(IElementFactory.class);
-    }
-
-    @BeforeGroups("timeout")
-    public void setupTimeout() {
-        System.setProperty(CONDITION_TIMEOUT_KEY, NEW_TIMEOUT_VALUE);
-        AqualityServices.resetInjector();
-    }
-
-    @AfterGroups("timeout")
-    public void resetTimeout() {
-        System.clearProperty(CONDITION_TIMEOUT_KEY);
-        AqualityServices.resetInjector();
     }
 
     private IElement getParentElement() {
@@ -65,69 +44,8 @@ public class ElementFactoryTests implements ITestWithApplication {
     }
 
     @Test
-    public void shouldBePossibleToFindCustomElementsViaCustomFactory() {
-        Assert.assertTrue(customFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class).size() > 1);
-    }
-
-    @Test
     public void shouldBePossibleToFindCustomElementsViaDefaultFactoryUsingImplementation() {
         Assert.assertTrue(defaultFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), CustomElement.class).size() > 1);
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaCustomFactoryWithCustomElementsCount() {
-        Assert.assertTrue(customFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.MORE_THEN_ZERO).size() > 1);
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaSupplierWithDefaultName() {
-        Assert.assertTrue(customFactory().findElements(
-                CalculatorWindow.getEqualsButtonByXPath(), CustomElement::new, ElementsCount.MORE_THEN_ZERO,
-                ElementState.EXISTS_IN_ANY_STATE).size() > 1);
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaSupplierWithCustomName() {
-        String customName = "56789";
-        Assert.assertTrue(customFactory().findElements(
-                CalculatorWindow.getEqualsButtonByXPath(), customName, CustomElement::new, ElementsCount.MORE_THEN_ZERO,
-                ElementState.EXISTS_IN_ANY_STATE).get(0).getName().contains(customName));
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaSupplierWithCustomState() {
-        Assert.assertEquals(customFactory().findElements(
-                CalculatorWindow.getEqualsButtonByXPath(), CustomElement::new, ElementsCount.MORE_THEN_ZERO,
-                ElementState.EXISTS_IN_ANY_STATE).get(0).getState(), ElementState.EXISTS_IN_ANY_STATE);
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaCustomFactoryWithDefaultElementsCount() {
-        Assert.assertTrue(customFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.ANY).size() > 1);
-    }
-
-    @Test
-    public void shouldSetCorrectParametersWhenFindElements() {
-        String customName = "asd";
-        ICustomElement element = customFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), customName, ICustomElement.class).get(1);
-        Assert.assertNotEquals(element.getName(), customName);
-        Assert.assertTrue(element.getName().contains(customName));
-        Assert.assertTrue(element.getLocator().toString().contains(CalculatorWindow.getEqualsButtonByXPath().toString().substring(XPATH_SUBSTRING_BEGIN_INDEX)));
-    }
-
-    @Test
-    public void shouldBePossibleToFindCustomElementsViaCustomFactoryWithZeroElementsCount() {
-        Assert.assertTrue(customFactory().findElements(By.name("any"), ICustomElement.class, ElementsCount.ANY).isEmpty());
-    }
-
-    @Test(groups = "timeout")
-    public void shouldThrowTimeoutExceptionWhenCountIsNotExpected() {
-        Assert.assertThrows(TimeoutException.class, () -> customFactory().findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.ZERO));
-    }
-
-    @Test
-    public void shouldThrowInvalidArgumentExceptionInFindElementsWhenLocatorIsNotSupported() {
-        Assert.assertThrows(InvalidArgumentException.class, () -> customFactory().findElements(CalculatorWindow.getEqualsButtonLoc(), ICustomElement.class, ElementsCount.MORE_THEN_ZERO));
     }
 
     @Test
@@ -203,5 +121,30 @@ public class ElementFactoryTests implements ITestWithApplication {
     @Override
     public boolean isApplicationStarted() {
         return AqualityServices.isApplicationStarted();
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementsCount count) {
+        return customFactory().findElements(locator, clazz, count);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz) {
+        return customFactory().findElements(locator, clazz);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz) {
+        return customFactory().findElements(locator, name, clazz);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        return customFactory().findElements(locator, name, supplier, count, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        return customFactory().findElements(locator, supplier, count, state);
     }
 }

--- a/src/test/java/tests/elements/factory/FindChildElementsTests.java
+++ b/src/test/java/tests/elements/factory/FindChildElementsTests.java
@@ -1,0 +1,55 @@
+package tests.elements.factory;
+
+import aquality.selenium.core.applications.IApplication;
+import aquality.selenium.core.elements.ElementState;
+import aquality.selenium.core.elements.ElementsCount;
+import aquality.selenium.core.elements.interfaces.IElement;
+import aquality.selenium.core.elements.interfaces.IElementSupplier;
+import org.openqa.selenium.By;
+import tests.ITestWithApplication;
+import tests.applications.windowsApp.AqualityServices;
+import tests.applications.windowsApp.CalculatorWindow;
+
+import java.util.List;
+
+public class FindChildElementsTests implements ITestWithApplication, IFindElementsTests  {
+
+    @Override
+    public IApplication getApplication() {
+        return AqualityServices.getApplication();
+    }
+
+    @Override
+    public boolean isApplicationStarted() {
+        return AqualityServices.isApplicationStarted();
+    }
+
+    private IElement getParent() {
+        return CalculatorWindow.getWindowByXPathLabel();
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementsCount count) {
+        return customFactory().findChildElements(getParent(), locator, clazz, count);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz) {
+        return customFactory().findChildElements(getParent(), locator, clazz);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz) {
+        return customFactory().findChildElements(getParent(), locator, name, clazz);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, name, supplier, count, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, supplier, count, state);
+    }
+}

--- a/src/test/java/tests/elements/factory/FindChildElementsTests.java
+++ b/src/test/java/tests/elements/factory/FindChildElementsTests.java
@@ -6,13 +6,15 @@ import aquality.selenium.core.elements.ElementsCount;
 import aquality.selenium.core.elements.interfaces.IElement;
 import aquality.selenium.core.elements.interfaces.IElementSupplier;
 import org.openqa.selenium.By;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 import tests.ITestWithApplication;
 import tests.applications.windowsApp.AqualityServices;
 import tests.applications.windowsApp.CalculatorWindow;
 
 import java.util.List;
 
-public class FindChildElementsTests implements ITestWithApplication, IFindElementsTests  {
+public class FindChildElementsTests implements ITestWithApplication, IFindElementsTests {
 
     @Override
     public IApplication getApplication() {
@@ -34,6 +36,16 @@ public class FindChildElementsTests implements ITestWithApplication, IFindElemen
     }
 
     @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, name, clazz, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, clazz, state);
+    }
+
+    @Override
     public <T extends IElement> List<T> findElements(By locator, Class<T> clazz) {
         return customFactory().findChildElements(getParent(), locator, clazz);
     }
@@ -49,7 +61,33 @@ public class FindChildElementsTests implements ITestWithApplication, IFindElemen
     }
 
     @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, name, supplier, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementState state) {
+        return customFactory().findChildElements(getParent(), locator, supplier, state);
+    }
+
+    @Override
+    public <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier) {
+        return customFactory().findChildElements(getParent(), locator, name, supplier);
+    }
+
+    @Override
     public <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementsCount count, ElementState state) {
         return customFactory().findChildElements(getParent(), locator, supplier, count, state);
+    }
+
+    @Test
+    public void testShouldBePossibleToWorkWithElementsFoundBySpecificLocatorOfParent() {
+        List<ICustomElement> elements = customFactory().findChildElements(
+                CalculatorWindow.getWindowLabel(),
+                CalculatorWindow.getEqualsButtonByXPath(),
+                CustomElement::new);
+        Assert.assertFalse(elements.isEmpty());
+        Assert.assertEquals(elements.stream().map(IElement::getElement).toArray().length, elements.size(),
+                "elements count not match to expected");
     }
 }

--- a/src/test/java/tests/elements/factory/IFindElementsTests.java
+++ b/src/test/java/tests/elements/factory/IFindElementsTests.java
@@ -1,0 +1,116 @@
+package tests.elements.factory;
+
+import aquality.selenium.core.elements.ElementState;
+import aquality.selenium.core.elements.ElementsCount;
+import aquality.selenium.core.elements.interfaces.IElement;
+import aquality.selenium.core.elements.interfaces.IElementFinder;
+import aquality.selenium.core.elements.interfaces.IElementSupplier;
+import aquality.selenium.core.localization.ILocalizationManager;
+import aquality.selenium.core.waitings.IConditionalWait;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.TimeoutException;
+import org.testng.Assert;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+import tests.applications.windowsApp.AqualityServices;
+import tests.applications.windowsApp.CalculatorWindow;
+
+import java.util.List;
+
+public interface IFindElementsTests {
+    String CONDITION_TIMEOUT_KEY = "timeouts.timeoutCondition";
+    String NEW_TIMEOUT_VALUE = "5";
+    int XPATH_SUBSTRING_BEGIN_INDEX = 10;
+
+    <T extends IElement> List<T> findElements(By locator, Class<T> clazz, ElementsCount count);
+
+    <T extends IElement> List<T> findElements(By locator, Class<T> clazz);
+
+    <T extends IElement> List<T> findElements(By locator, String name, Class<T> clazz);
+
+    <T extends IElement> List<T> findElements(By locator, String name, IElementSupplier<T> supplier, ElementsCount count,
+                                              ElementState state);
+
+    <T extends IElement> List<T> findElements(By locator, IElementSupplier<T> supplier, ElementsCount count,
+                                              ElementState state);
+
+    default CustomElementFactory customFactory() {
+        return new CustomElementFactory(AqualityServices.get(IConditionalWait.class),
+                AqualityServices.get(IElementFinder.class), AqualityServices.get(ILocalizationManager.class));
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaCustomFactory() {
+        Assert.assertTrue(findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class).size() > 1);
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaCustomFactoryWithCustomElementsCount() {
+        Assert.assertTrue(findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.MORE_THEN_ZERO).size() > 1);
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaSupplierWithDefaultName() {
+        Assert.assertTrue(findElements(
+                CalculatorWindow.getEqualsButtonByXPath(), CustomElement::new, ElementsCount.MORE_THEN_ZERO,
+                ElementState.EXISTS_IN_ANY_STATE).size() > 1);
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaSupplierWithCustomName() {
+        String customName = "56789";
+        Assert.assertTrue(findElements(
+                CalculatorWindow.getEqualsButtonByXPath(), customName, CustomElement::new, ElementsCount.MORE_THEN_ZERO,
+                ElementState.EXISTS_IN_ANY_STATE).get(0).getName().contains(customName));
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaSupplierWithCustomState() {
+        Assert.assertEquals(findElements(
+                CalculatorWindow.getEqualsButtonByXPath(), CustomElement::new, ElementsCount.MORE_THEN_ZERO,
+                ElementState.EXISTS_IN_ANY_STATE).get(0).getState(), ElementState.EXISTS_IN_ANY_STATE);
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaCustomFactoryWithDefaultElementsCount() {
+        Assert.assertTrue(findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.ANY).size() > 1);
+    }
+
+    @Test
+    default void shouldSetCorrectParametersWhenFindElements() {
+        String customName = "asd";
+        ICustomElement element = findElements(CalculatorWindow.getEqualsButtonByXPath(), customName, ICustomElement.class).get(1);
+        Assert.assertNotEquals(element.getName(), customName);
+        Assert.assertTrue(element.getName().contains(customName));
+        Assert.assertTrue(element.getLocator().toString().contains(CalculatorWindow.getEqualsButtonByXPath().toString().substring(XPATH_SUBSTRING_BEGIN_INDEX)));
+    }
+
+    @Test
+    default void shouldBePossibleToFindCustomElementsViaCustomFactoryWithZeroElementsCount() {
+        Assert.assertTrue(findElements(By.xpath("//any"), ICustomElement.class, ElementsCount.ANY).isEmpty());
+    }
+
+    @Test(groups = "timeout")
+    default void shouldThrowTimeoutExceptionWhenCountIsNotExpected() {
+        Assert.assertThrows(TimeoutException.class, () -> findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class, ElementsCount.ZERO));
+    }
+
+    @Test
+    default void shouldThrowInvalidArgumentExceptionInFindElementsWhenLocatorIsNotSupported() {
+        Assert.assertThrows(InvalidArgumentException.class, () -> findElements(CalculatorWindow.getEqualsButtonLoc(), ICustomElement.class, ElementsCount.MORE_THEN_ZERO));
+    }
+
+    @BeforeGroups("timeout")
+    default void setupTimeout() {
+        System.setProperty(CONDITION_TIMEOUT_KEY, NEW_TIMEOUT_VALUE);
+        AqualityServices.resetInjector();
+    }
+
+    @AfterGroups("timeout")
+    default void resetTimeout() {
+        System.clearProperty(CONDITION_TIMEOUT_KEY);
+        AqualityServices.resetInjector();
+    }
+}

--- a/src/test/java/tests/elements/factory/IFindElementsTests.java
+++ b/src/test/java/tests/elements/factory/IFindElementsTests.java
@@ -66,6 +66,7 @@ public interface IFindElementsTests {
         List<By> locators = new ArrayList<>();
         locators.add(CalculatorWindow.getDottedXPathLocator());
         locators.add(CalculatorWindow.getTagNameLocator());
+        locators.add(CalculatorWindow.getRelativeXPathLocator());
         return locators.toArray();
     }
 

--- a/src/test/java/tests/elements/factory/IFindElementsTests.java
+++ b/src/test/java/tests/elements/factory/IFindElementsTests.java
@@ -42,6 +42,14 @@ public interface IFindElementsTests {
     }
 
     @Test
+    default void testShouldBePossibleToWorkWithElementsFoundByDottedLocator(){
+        List<ICustomElement> elements = findElements(CalculatorWindow.getDottedXPathLocator(), ICustomElement.class);
+        Assert.assertFalse(elements.isEmpty());
+        Assert.assertEquals(elements.stream().map(IElement::getElement).toArray().length, elements.size(),
+                "elements count not match to expected");
+    }
+
+    @Test
     default void shouldBePossibleToFindCustomElementsViaCustomFactory() {
         Assert.assertTrue(findElements(CalculatorWindow.getEqualsButtonByXPath(), ICustomElement.class).size() > 1);
     }


### PR DESCRIPTION
### PR Details

- Implement FindChildElements functionality for ElementFactory and IElement.
- Reworked locator generation in order to support non-web libraries, such as Appium, where javascript execution for xpath generation is not supported.
- Add missed overloads to findElements.
- Covered all methods by tests.

##### Related Issue Link: 

closes #45 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

##### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

##### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
